### PR TITLE
Adding releasenameoverride with tpl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,36 @@ blobstorage:
 java:
   secrets:
     BLOB_ACCOUNT_NAME:
-      secretRef: storage-secret-${SERVICE_NAME}
+      secretRef: storage-secret-{{ .Release.Name }}
       key: storageAccountName
     BLOB_ACCESS_KEY:
-      secretRef: storage-secret-${SERVICE_NAME}
+      secretRef: storage-secret-{{ .Release.Name }}
       key: accessKey
     BLOB_SERVICE_ENDPOINT:
-      secretRef: storage-secret-${SERVICE_NAME}
+      secretRef: storage-secret-{{ .Release.Name }}
+      key: primaryBlobServiceEndPoint
+```
+If using releaseNameOverride, secretRef will be updated as in below
+
+```yaml
+releaseNameOverride: example-release-name
+blobstorage:
+    resourceGroup: yyyy
+    teamName: myTeam
+    setup:
+      containers:
+      - first-container
+      - second-container
+java:
+  secrets:
+    BLOB_ACCOUNT_NAME:
+      secretRef: storage-secret-example-release-name
+      key: storageAccountName
+    BLOB_ACCESS_KEY:
+      secretRef: storage-secret-example-release-name
+      key: accessKey
+    BLOB_SERVICE_ENDPOINT:
+      secretRef: storage-secret-example-release-name
       key: primaryBlobServiceEndPoint
 ```
 
@@ -50,10 +73,10 @@ The following table lists the configurable parameters of the Blob Storage chart 
 
 | Parameter      | Type | Description | Default |
 | -------------- | ---- | ----------- | ------- |
+| `releaseNameOverride`          | Will override the resource name - It supports templating, example:`releaseNameOverride: {{ .Release.Name }}-my-custom-name`      | `Release.Name-Chart.Name`     |
 | `location` | string | location of the PaaS instance of the blob storage to use | `uksouth` |
 | `resourceGroup` | string | resource group required for the Azure deployment |  **Required** |
 | `teamName` | string | team name used to create related Azure tag |  **Required** |
-| `secretNameSuffix`            | string   | Suffix for secret names added by chart.By default release name is used as suffix| **Optional** |
 | `setup` | array | see the full description of the setup objects in [setup objects](#setupobjects)| **Required** |
 | `setup.containers` | array | The names of the containers. | **Required**|
 | `setup.enableNonHttpsTraffic` | `string` |  Specify whether non-https traffic is enabled. | `disabled`|

--- a/blobstorage/Chart.yaml
+++ b/blobstorage/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to access Azure blob storage
 name: blobstorage
-version: 0.0.4
+version: 0.1.0
 icon: https://github.com/hmcts/chart-blobstorage/raw/master/images/storage_icon.png
-keywords: 
+keywords:
 - azure
 - blob storage

--- a/blobstorage/templates/_helpers.tpl
+++ b/blobstorage/templates/_helpers.tpl
@@ -7,10 +7,11 @@ helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/instance: {{ .Release.Name -}}
 {{- end -}}
-{{- define "secretNameSuffix" -}}
-{{- if .Values.secretNameSuffix -}}
-{{- .Values.secretNameSuffix -}}
+
+{{- define "hmcts.releaseName" -}}
+{{- if .Values.releaseNameOverride -}}
+{{- tpl .Values.releaseNameOverride $ | trunc 53 | trimSuffix "-" -}}
 {{- else -}}
-{{- .Release.Name -}}
+{{- .Release.Name | trunc 53 -}}
 {{- end -}}
 {{- end -}}

--- a/blobstorage/templates/deployment.yaml
+++ b/blobstorage/templates/deployment.yaml
@@ -5,7 +5,7 @@
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ServiceInstance
 metadata:
-  name: storage-service-{{ .Release.Name }}
+  name: storage-service-{{ template "hmcts.releaseName" . }}
   labels:
     {{- ( include "labels" . ) | indent 4 }}
 spec:
@@ -13,54 +13,54 @@ spec:
   clusterServicePlanExternalName: account
   parameters:
     location: {{ .Values.location }}
-    alias: storage-account-{{ .Release.Name }}
+    alias: storage-account-{{ template "hmcts.releaseName" . }}
     resourceGroup: {{ required "A resource group ( .Values.resourceGroup ) is required for storage creation" .Values.resourceGroup | quote }}
-    enableNonHttpsTraffic: {{ .Values.enableNonHttpsTraffic | default "disabled" | quote }} 
+    enableNonHttpsTraffic: {{ .Values.enableNonHttpsTraffic | default "disabled" | quote }}
     tags:
-      app.kubernetes.io_name: {{ .Release.Name }}
+      app.kubernetes.io_name: {{ template "hmcts.releaseName" . }}
       helm.sh_chart: {{ .Chart.Name }}-{{ .Chart.Version }}
       "Team Name": {{ required "A team name (.Values.teamName) is required" .Values.teamName }}
 ---
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ServiceBinding
 metadata:
-  name: storage-binding-{{ .Release.Name }}
+  name: storage-binding-{{ template "hmcts.releaseName" . }}
   labels:
     {{- ( include "labels" . ) | indent 4 }}
 spec:
   instanceRef:
-    name: storage-service-{{ .Release.Name }}
-  secretName: storage-secret-{{ template "secretNameSuffix" . }}
-   
+    name: storage-service-{{ template "hmcts.releaseName" . }}
+  secretName: storage-secret-{{ template "hmcts.releaseName" . }}
+
 {{- if .Values.setup -}}
   {{- if .Values.setup.containers -}}
-    {{- $base := . -}} 
+    {{- $base := . -}}
     {{ range .Values.setup.containers }}
 
 ---
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ServiceInstance
 metadata:
-  name: container-{{ $base.Release.Name }}-{{ required "All .Values.setup.containers items need a 'name' property" . }}
+  name: container-{{ template "hmcts.releaseName" $base }}-{{ required "All .Values.setup.containers items need a 'name' property" . }}
   labels:
     {{- ( include "labels" $base ) | indent 4 }}
 spec:
   clusterServiceClassExternalName: azure-storage-blob-container
   clusterServicePlanExternalName: container
   parameters:
-    parentAlias: storage-account-{{ $base.Release.Name }}
+    parentAlias: storage-account-{{ template "hmcts.releaseName" $base }}
     containerName: {{ . }}
 ---
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ServiceBinding
 metadata:
-  name: container-binding-{{ $base.Release.Name }}-{{ . }}
+  name: container-binding-{{ template "hmcts.releaseName" $base }}-{{ . }}
   labels:
     {{- (include "labels" $base) | indent 4 }}
 spec:
   instanceRef:
-    name: container-{{ $base.Release.Name }}-{{ . }}
-  secretName: container-secret-{{ template "secretNameSuffix" $base }}-{{ . }}
+    name: container-{{ template "hmcts.releaseName" $base }}-{{ . }}
+  secretName: container-secret-{{ template "hmcts.releaseName" $base }}-{{ . }}
     {{ end }}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION

Verified that no one is using secretnamesuffix currently and releasenameoveride makes it consistent with chart-servicebus
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
