### PR TITLE
Fix container resources duplication issue - different azure name from k8s resource name

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Default configuration (e.g. default image and ingress host) is setup for sandbox
 
 ## Azure DevOps Builds
 
-Builds are run against the 'nonprod' AKS cluster.
+Builds are run against the 'cft-preview' AKS cluster. Any troubleshooting can be done within the chart-tests namespace on the cft-preview cluster.
 
 ### Pull Request Validation
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
   - template: steps/charts/validate.yaml@cnp-library
     parameters :
       chartName: blobstorage
-      chartReleaseName: chartcitest
+      chartReleaseName: chart-storage-ci
       chartNamespace: chart-tests
       helmDeleteWait: "150"
       helmInstallWait: "150"

--- a/blobstorage/templates/_helpers.tpl
+++ b/blobstorage/templates/_helpers.tpl
@@ -16,10 +16,6 @@ app.kubernetes.io/instance: {{ template "hmcts.blobstorage.releaseName" . }}
 {{- end -}}
 {{- end -}}
 
-{{- define "hmcts.blobstorage.storageAccountSha" -}}
-{{- include "hmcts.blobstorage.releaseName" . | sha256sum -}}
-{{- end -}}
-
 {{- define "hmcts.blobstorage.storageAccountName" -}}
-{{- include "hmcts.blobstorage.storageAccountSha" . | trunc -24 -}}
+{{- include "hmcts.blobstorage.releaseName" . | sha256sum | trunc -24 -}}
 {{- end -}}

--- a/blobstorage/templates/_helpers.tpl
+++ b/blobstorage/templates/_helpers.tpl
@@ -19,3 +19,7 @@ app.kubernetes.io/instance: {{ template "hmcts.blobstorage.releaseName" . }}
 {{- define "hmcts.blobstorage.storageAccountName" -}}
 {{- include "hmcts.blobstorage.releaseName" . | sha256sum | trunc -24 -}}
 {{- end -}}
+
+{{- define "hmcts.blobstorage.storageContainerPrefix" -}}
+{{- include "hmcts.blobstorage.releaseName" . | sha256sum -}}
+{{- end -}}

--- a/blobstorage/templates/_helpers.tpl
+++ b/blobstorage/templates/_helpers.tpl
@@ -16,10 +16,10 @@ app.kubernetes.io/instance: {{ template "hmcts.blobstorage.releaseName" . }}
 {{- end -}}
 {{- end -}}
 
-{{- define "hmcts.blobstorage.storageAccountName" -}}
-{{- include "hmcts.blobstorage.releaseName" . | sha256sum | trunc -24 -}}
+{{- define "hmcts.blobstorage.storageAccountSha" -}}
+{{- include "hmcts.blobstorage.releaseName" . | sha256sum -}}
 {{- end -}}
 
-{{- define "hmcts.blobstorage.storageContainerPrefix" -}}
-{{- include "hmcts.blobstorage.releaseName" . | sha256sum -}}
+{{- define "hmcts.blobstorage.storageAccountName" -}}
+{{- include "hmcts.blobstorage.storageAccountSha" . | trunc -24 -}}
 {{- end -}}

--- a/blobstorage/templates/deployment.yaml
+++ b/blobstorage/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
 apiVersion: storage.azure.com/v1beta20210401
 kind: StorageAccountsBlobServicesContainer
 metadata:
-  name: {{ . }}
+  name: {{ template "hmcts.blobstorage.storageAccountName" $ }}-{{ . }}
 spec:
   owner:
     name: storage-blobservice-{{ template "hmcts.blobstorage.releaseName" $ }}

--- a/blobstorage/templates/deployment.yaml
+++ b/blobstorage/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
 apiVersion: storage.azure.com/v1beta20210401
 kind: StorageAccountsBlobServicesContainer
 metadata:
-  name: {{ template "hmcts.blobstorage.storageContainerPrefix" . }}-{{ . }}
+  name: {{ . }}
 spec:
   owner:
     name: storage-blobservice-{{ template "hmcts.blobstorage.releaseName" $ }}

--- a/blobstorage/templates/deployment.yaml
+++ b/blobstorage/templates/deployment.yaml
@@ -49,10 +49,11 @@ spec:
 apiVersion: storage.azure.com/v1beta20210401
 kind: StorageAccountsBlobServicesContainer
 metadata:
-  name: {{ . }}
+  name: {{ template "hmcts.blobstorage.storageContainerPrefix" . }}-{{ . }}
 spec:
   owner:
     name: storage-blobservice-{{ template "hmcts.blobstorage.releaseName" $ }}
+  azureName: {{ . }}
 {{- end }}
 
 ---


### PR DESCRIPTION
Fix to enable multiple PRs to be ran
Fixing - Error: rendered manifests contain a resource that already exists ... invalid ownership metadata ... release-name" must equal "bulk-scan-processor-pr-x": current value is "bulk-scan-processor-pr-y" without needing tests changed by setting the k8s resource to a different name from the resource in Azure

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
